### PR TITLE
Add test case for appointment email sent

### DIFF
--- a/app/Http/Controllers/AppointmentController.php
+++ b/app/Http/Controllers/AppointmentController.php
@@ -32,8 +32,7 @@ class AppointmentController extends Controller
         $newAppt = $this->appointment->createAppointment($params);
 
         if (is_string($newAppt)) {
-            return response($newAppt, 404)
-            ->header('Content-Type', 'text/plain');
+            return response($newAppt, 404)->header('Content-Type', 'text/plain');
         }
 
         $this->sendEmail($newAppt);

--- a/app/Http/Controllers/AppointmentController.php
+++ b/app/Http/Controllers/AppointmentController.php
@@ -31,6 +31,11 @@ class AppointmentController extends Controller
 
         $newAppt = $this->appointment->createAppointment($params);
 
+        if (is_string($newAppt)) {
+            return response($newAppt, 404)
+            ->header('Content-Type', 'text/plain');
+        }
+
         $this->sendEmail($newAppt);
 
         return $newAppt;

--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -56,11 +56,11 @@ class Appointment extends Model
         $user = User::find(Arr::get($params, 'user_id'));
 
         if (! $user) {
-            return 'Unable to create appointment: User not found!';
+            return 'Unable to create appointment: User not found.';
         }
 
         if (! $type = Type::find(Arr::get($params, 'type_id'))) {
-            return 'Unable to create appointment: Type does not exist!';
+            return 'Unable to create appointment: Type does not exist.';
         }
 
         $createdAppointment = $user->appointments()->create([

--- a/tests/Feature/AppointmentTest.php
+++ b/tests/Feature/AppointmentTest.php
@@ -136,7 +136,7 @@ class AppointmentTest extends TestCase
         $response->assertContent('Appointment not found.');
     }
 
-    public function testSendEmailAppointmentCreated():void
+    public function testSendEmailAppointmentCreated(): void
     {
         Mail::fake();
 
@@ -165,7 +165,7 @@ class AppointmentTest extends TestCase
         });
     }
 
-    public function testEmailNotSentNoTypeId():void
+    public function testEmailNotSentNoTypeId(): void
     {
         Mail::fake();
 
@@ -181,6 +181,7 @@ class AppointmentTest extends TestCase
         $response = $this->post('/api/appointment', $data);
 
         $response->assertStatus(404);
+        $response->assertContent('Unable to create appointment: Type does not exist.');
 
         Mail::assertNothingSent();
     }
@@ -201,7 +202,8 @@ class AppointmentTest extends TestCase
         $response = $this->post('/api/appointment', $data);
 
         $response->assertStatus(404);
-        
+        $response->assertContent('Unable to create appointment: User not found.');
+
         Mail::assertNothingSent();
     }
 }

--- a/tests/Feature/AppointmentTest.php
+++ b/tests/Feature/AppointmentTest.php
@@ -165,7 +165,7 @@ class AppointmentTest extends TestCase
         });
     }
 
-    public function testSendEmailNotSentAppointmentCreated():void
+    public function testEmailNotSentNoTypeId():void
     {
         Mail::fake();
 
@@ -182,6 +182,26 @@ class AppointmentTest extends TestCase
 
         $response->assertStatus(404);
 
+        Mail::assertNothingSent();
+    }
+
+    public function testEmailNotSentNoUserId(): void
+    {
+        Mail::fake();
+
+        $type = Type::factory()->create();
+
+        $data = [
+            'type_id' => $type->id,
+            'date_of_appointment' => '2023-10-15 08:30:00',
+        ];
+
+        Mail::assertNothingSent();
+
+        $response = $this->post('/api/appointment', $data);
+
+        $response->assertStatus(404);
+        
         Mail::assertNothingSent();
     }
 }

--- a/tests/Feature/AppointmentTest.php
+++ b/tests/Feature/AppointmentTest.php
@@ -164,4 +164,24 @@ class AppointmentTest extends TestCase
                 $mail->appointment->type->name === $createdAppointment->type->name;
         });
     }
+
+    public function testSendEmailNotSentAppointmentCreated():void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create();
+
+        $data = [
+            'user_id' => $user->id,
+            'date_of_appointment' => '2023-03-07 15:30:00',
+        ];
+
+        Mail::assertNothingSent();
+
+        $response = $this->post('/api/appointment', $data);
+
+        $response->assertStatus(404);
+
+        Mail::assertNothingSent();
+    }
 }


### PR DESCRIPTION
Test cases added: 
- Success email sent when appointment created
- Failure for missing type_id or user_id for params
     - Add in http response codes for when type and user do not exist